### PR TITLE
Use std::chrono::seconds to denote, well, seconds.

### DIFF
--- a/include/sdl++/power.hpp
+++ b/include/sdl++/power.hpp
@@ -29,6 +29,8 @@
 
 #include "SDL_power.h"
 
+#include <chrono>
+
 namespace sdl {
 
 /*!
@@ -43,8 +45,9 @@ namespace sdl {
 
  if (info.state == sdl::power_state::on_battery &&
      info.secs_left && info.percent_left) {
-     std::cout << "Running on battery with " << info.secs_left
-               << "seconds of power remaining (" << info.percent_left << "%)\n";
+     std::cout << "Running on battery with " << info.secs_left.value()
+               << " seconds of power remaining (" << info.percent_left.value()
+               << "%)\n";
  }
 
  ```
@@ -82,12 +85,24 @@ struct power_info {
 
     //! Estimated seconds of battery life left. May be absent if we can't
     //! determine a value, or we're not running on a battery
-    optional<int> secs_left = nullopt;
+    optional<std::chrono::seconds> secs_left = nullopt;
 
-    //! percentage of battery life left, between 0 and 100. May be absent if we
+    //! Percentage of battery life left, between 0 and 100. May be absent if we
     //! can't determine a value, or we're not running on a battery
     optional<int> percent_left = nullopt;
 };
+
+//! @related power_info
+// TODO: In theory this function can be constexpr one day
+bool operator==(const power_info& lhs, const power_info& rhs) {
+    return std::tie(lhs.state, lhs.secs_left, lhs.percent_left) ==
+           std::tie(rhs.state, rhs.secs_left, rhs.percent_left);
+}
+
+//! @related power_info
+bool operator!=(const power_info& lhs, const power_info& rhs) {
+    return !(lhs == rhs);
+}
 
 //! Get the current power supply details
 inline power_info get_power_info() {
@@ -96,14 +111,12 @@ inline power_info get_power_info() {
     int percent = 0;
     info.state = wrap(::SDL_GetPowerInfo(&secs, &percent));
 
-    if (secs != -1) { info.secs_left = secs; }
+    if (secs != -1) { info.secs_left = std::chrono::seconds{secs}; }
 
     if (percent != -1) { info.percent_left = percent; }
 
     return info;
 }
-
-//! @}
 
 } // end namespace sdl
 

--- a/include/sdl++/power.hpp
+++ b/include/sdl++/power.hpp
@@ -76,20 +76,19 @@ power_state wrap(SDL_PowerState state) {
     return static_cast<power_state>(state);
 }
 
-/*!
- Power information
- */
+//! Power information
+// TODO(MSVC): Add NSDMIs once MSVC supports aggregate initialization using them
 struct power_info {
     //! The state of the battery (if any)
-    power_state state = power_state::unknown;
+    power_state state; // = power_state::unknown
 
     //! Estimated seconds of battery life left. May be absent if we can't
     //! determine a value, or we're not running on a battery
-    optional<std::chrono::seconds> secs_left = nullopt;
+    optional<std::chrono::seconds> secs_left; // = nullopt
 
     //! Percentage of battery life left, between 0 and 100. May be absent if we
     //! can't determine a value, or we're not running on a battery
-    optional<int> percent_left = nullopt;
+    optional<int> percent_left; // = nullopt;
 };
 
 //! @related power_info

--- a/test/power.test.cpp
+++ b/test/power.test.cpp
@@ -5,19 +5,30 @@
 
 #include <gtest/gtest.h>
 
+using namespace std::chrono_literals;
+
 struct power : ::testing::Test {
     power() { ::SDL_Init(SDL_INIT_EVENTS); }
 
     ~power() { ::SDL_Quit(); }
 };
 
-TEST_F(power, basic) {
+TEST_F(power, rel_ops) {
+    sdl::power_info p1{};
+    sdl::power_info p2{sdl::power_state::on_battery, 3600s, 58};
+
+    EXPECT_EQ(p1, p1);
+    EXPECT_EQ(p2, p2);
+    EXPECT_NE(p1, p2);
+}
+
+TEST_F(power, get_info) {
     auto info = sdl::get_power_info();
 
     int c_secs, c_pct;
     auto c_state = SDL_GetPowerInfo(&c_secs, &c_pct);
 
     EXPECT_EQ(c_state, static_cast<SDL_PowerState>(info.state));
-    EXPECT_EQ(c_secs, info.secs_left.value_or(-1));
+    EXPECT_EQ(c_secs, info.secs_left.value_or(-1s).count());
     EXPECT_EQ(c_pct, info.percent_left.value_or(-1));
 }


### PR DESCRIPTION
Type safety FTW.

Also, make sdl::power_info EqualityComparable, because it's good
practice and there's no reason why not
