### PR TITLE
Rename bundled std::experimental::optional to sdl::optional

### DIFF
--- a/include/sdl++/stdinc.hpp
+++ b/include/sdl++/stdinc.hpp
@@ -30,14 +30,13 @@
 
 #ifdef __cpp_lib_experimental_optional
 #include <experimental/optional>
-#else
-#include "external/optional.hpp"
-#endif
-
 namespace sdl {
 using std::experimental::optional;
 using std::experimental::nullopt;
 }
+#else
+#include "external/optional.hpp"
+#endif
 
 /* Add namespaced typedefs for sized integer types. This is utterly pointless
    as the original versions are typedef'd in SDL_stdinc.h and so already exist


### PR DESCRIPTION
Adding anything to namespace std is technically undefined
behaviour.

While it wasn't actually causing any problems, this still makes me
a bit nervous, so let's rename our bundled copy of optional to
sdl::optional instead.
