### PR TITLE
Do not build SDL2 shared library for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ cmake_minimum_required(VERSION 2.8)
 
 project(sdl++ C CXX)
 
+include(CTest)
+enable_testing()
+
+add_subdirectory(external)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -pedantic")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror")
@@ -14,19 +19,8 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 endif()
 
-include(CTest)
-enable_testing()
-
-add_subdirectory(external)
-
 include_directories(external/SDL2/include)
 include_directories(include)
-
-option(SDLXX_USE_EXCEPTIONS "Whether to use exceptions for tests" ON)
-if (NOT SDLXX_USE_EXCEPTIONS)
-    message(STATUS "Not using exceptions for tests")
-    add_definitions(-DSDLXX_NO_EXCEPTIONS)
-endif()
 
 add_subdirectory(doc)
 add_subdirectory(example)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 function(add_example name)
     add_executable(${name} ${name}.cpp)
-    target_link_libraries(${name} SDL2 SDL2main)
+    target_link_libraries(${name} SDL2-static SDL2main)
 endfunction(add_example)
 
 add_example(example1)
@@ -9,4 +9,4 @@ add_example(example2)
 
 # Add the C example too
 add_executable(c_example1 example1.c)
-target_link_libraries(c_example1 SDL2 SDL2main)
+target_link_libraries(c_example1 SDL2-static SDL2main)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,2 +1,3 @@
 
+set(SDL_SHARED OFF CACHE BOOL "Whether to build a shared version of SDL")
 add_subdirectory(SDL2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(test-sdl++
     version_test.cpp
     )
 
-target_link_libraries(test-sdl++ SDL2 SDL2main)
+target_link_libraries(test-sdl++ SDL2-static SDL2main)
 
 add_test(test-sdl++ test-sdl++)
 


### PR DESCRIPTION
...but only statically, rather than pointlessly doing the same work twice (CMake doesn’t share object files between targets). This speeds up CI builds.

The alternative would be to only build a shared SDL2, but unfortunately this causes random hangs on the Appveyor tests and I don’t have a Windows machine to build on myself to diagnose.

Also, if we ever get round to doing Android or iOS test builds then these will need to be static anyway.
