### PR TITLE
Use a local copy of SDL2 if one is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,10 @@ before_install:
   - set -e
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      brew update && brew install cmake ninja doxygen;
+      brew update && brew install cmake sdl2 ninja;
+      if [[ "${DOCUMENTATION}"  == "true" ]]; then
+        brew install doxygen
+      fi
     fi
 
 # Run cmake to generate makefiles in 'builds' directory.
@@ -84,7 +87,7 @@ script:
 after_success:
   - |
     if [[ "${DOCUMENTATION}" == "true" ]]; then
-      (ninja doc)
+      cmake --build . --target doc
       if [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
         # Suppress output to avoid leaking the token when the command fails
         git clone https://tcbrindle:${GITHUB_TOKEN}@github.com/tcbrindle/sdlxx --depth 1 --branch=gh-pages gh-pages &>/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,15 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
             - kalakris-cmake
+      cache: &sdl_cache
+        directories:
+          - $HOME/SDL2
 
     - os: linux
       env: CONFIGURATION=Release COMPILER=g++-5
       compiler: gcc
       addons: *gcc5
+      cache: *sdl_cache
 
     - os: linux
       env: CONFIGURATION=Debug COMPILER=clang++-3.6
@@ -47,11 +51,13 @@ matrix:
             - cmake
             - ninja-build
           sources: *sources
+      cache: *sdl_cache
 
     - os: linux
       env: CONFIGURATION=Release COMPILER=clang++-3.6
       compiler: clang
       addons: *clang36
+      cache: *sdl_cache
 
     - os: osx
       env: CONFIGURATION=Debug COMPILER=clang++ DOCUMENTATION=true
@@ -64,6 +70,15 @@ matrix:
 # Install SDL2
 before_install:
   - set -e
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      if [ ! -d "$HOME/SDL2/lib" ]; then
+          wget https://www.libsdl.org/release/SDL2-2.0.4.tar.gz;
+          tar -xzf SDL2-2.0.4.tar.gz;
+          cd SDL2-2.0.4 && ./configure --prefix=$HOME/SDL2 && make -j2 && make install;
+      fi
+      export SDL2DIR=$HOME/SDL2
+    fi
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       brew update && brew install cmake sdl2 ninja;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,18 @@ cmake_minimum_required(VERSION 2.8)
 
 project(sdl++ C CXX)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${sdl++_SOURCE_DIR}/cmake")
+
 include(CTest)
 enable_testing()
 
-add_subdirectory(external)
+find_package(SDL2)
+
+if (NOT SDL2_FOUND)
+    add_subdirectory(external)
+    set(SDL2_LIBRARY SDL2-static SDL2main)
+    set(SDL2_INCLUDE_DIR "${sdl++_SOURCE_DIR}/external/SDL2/include")
+endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -pedantic")
@@ -19,8 +27,8 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 endif()
 
-include_directories(external/SDL2/include)
 include_directories(include)
+include_directories(${SDL2_INCLUDE_DIR})
 
 add_subdirectory(doc)
 add_subdirectory(example)

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,0 +1,164 @@
+
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES lib64 lib
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES lib64 lib
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 function(add_example name)
     add_executable(${name} ${name}.cpp)
-    target_link_libraries(${name} SDL2-static SDL2main)
+    target_link_libraries(${name} ${SDL2_LIBRARY})
 endfunction(add_example)
 
 add_example(example1)
@@ -9,4 +9,4 @@ add_example(example2)
 
 # Add the C example too
 add_executable(c_example1 example1.c)
-target_link_libraries(c_example1 SDL2-static SDL2main)
+target_link_libraries(c_example1 ${SDL2_LIBRARY})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(test-sdl++
     version_test.cpp
     )
 
-target_link_libraries(test-sdl++ SDL2-static SDL2main)
+target_link_libraries(test-sdl++ ${SDL2_LIBRARY})
 
 add_test(test-sdl++ test-sdl++)
 


### PR DESCRIPTION
This was what we did originally, dumped in favour of using a Git
submodule and building SDL that way.

But come to think of it, most users will probably be using an
installed copy, so let's test with that. It will (should) also
save CI build time.

Note that this approach still has SDL2 as a submodule and will
attempt to build and statically link it if a system installation
can't be found. This should allow future testing on iOS and other
platforms at some point.
