### PR TITLE
Use automatic argument conversion where possible

### DIFF
--- a/include/sdl++/clipboard.hpp
+++ b/include/sdl++/clipboard.hpp
@@ -43,10 +43,16 @@ inline void set_clipboard_text(const char* text) {
     SDLXX_CHECK(::SDL_SetClipboardText(text) == 0);
 }
 
+//! Put UTF-8 text into the clipboard
+//! @throws sdl::error on failure
+inline void set_clipboard_text(const string& text) {
+    SDLXX_CHECK(detail::c_call(::SDL_SetClipboardText, text) == 0);
+}
+
 //! Get UTF-8 text from the clipboard
 //! @returns The clipboard contents, or an empty string
 inline string get_clipboard_text() {
-    return detail::take_string(::SDL_GetClipboardText());
+    return detail::c_call(::SDL_GetClipboardText);
 }
 
 //! Returns a flag indicating whether the clipboard exists and contains a text

--- a/include/sdl++/clipboard.hpp
+++ b/include/sdl++/clipboard.hpp
@@ -24,8 +24,8 @@
 
 #include "SDL_clipboard.h"
 
-#include "stdinc.hpp"
 #include "macros.hpp"
+#include "stdinc.hpp"
 #include "utils.hpp"
 
 namespace sdl {
@@ -52,7 +52,7 @@ inline string get_clipboard_text() {
 //! Returns a flag indicating whether the clipboard exists and contains a text
 //! string that is non-empty
 inline bool has_clipboard_text() {
-    return ::SDL_HasClipboardText() == SDL_TRUE;
+    return detail::c_call(::SDL_HasClipboardText);
 }
 
 } // end namespace sdl

--- a/include/sdl++/cpuinfo.hpp
+++ b/include/sdl++/cpuinfo.hpp
@@ -26,6 +26,8 @@
 
 #include "SDL_cpuinfo.h"
 
+#include "utils.hpp"
+
 namespace sdl {
 
 /*!
@@ -38,7 +40,7 @@ namespace sdl {
  */
 
 //! This function returns the number of CPU cores available.
-inline int get_cpu_count() { return ::SDL_GetCPUCount(); }
+inline int get_cpu_count() { return detail::c_call(::SDL_GetCPUCount); }
 
 /*!
  This function returns the L1 cache line size of the CPU
@@ -46,43 +48,45 @@ inline int get_cpu_count() { return ::SDL_GetCPUCount(); }
  This is useful for determining multi-threaded structure padding
  or SIMD prefetch sizes.
  */
-inline int get_cpu_cache_line_size() { return ::SDL_GetCPUCacheLineSize(); }
+inline int get_cpu_cache_line_size() {
+    return detail::c_call(::SDL_GetCPUCacheLineSize);
+}
 
 //! This function returns true if the CPU has the RDTSC instruction.
-inline bool cpu_has_rdtsc() { return ::SDL_HasRDTSC() == SDL_TRUE; }
+inline bool cpu_has_rdtsc() { return detail::c_call(::SDL_HasRDTSC); }
 
 //! This function returns true if the CPU has AltiVec features.
-inline bool cpu_has_altivec() { return ::SDL_HasAltiVec() == SDL_TRUE; }
+inline bool cpu_has_altivec() { return detail::c_call(::SDL_HasAltiVec); }
 
 //! This function returns true if the CPU has MMX features.
-inline bool cpu_has_mmx() { return ::SDL_HasMMX() == SDL_TRUE; }
+inline bool cpu_has_mmx() { return detail::c_call(::SDL_HasMMX); }
 
 //! This function returns true if the CPU has 3DNow! features.
-inline bool cpu_has_3dnow() { return ::SDL_Has3DNow() == SDL_TRUE; }
+inline bool cpu_has_3dnow() { return detail::c_call(::SDL_Has3DNow); }
 
 //! This function returns true if the CPU has SSE features.
-inline bool cpu_has_sse() { return ::SDL_HasSSE() == SDL_TRUE; }
+inline bool cpu_has_sse() { return detail::c_call(::SDL_HasSSE); }
 
 //! This function returns true if the CPU has SSE2 features.
-inline bool cpu_has_sse2() { return ::SDL_HasSSE2() == SDL_TRUE; }
+inline bool cpu_has_sse2() { return detail::c_call(::SDL_HasSSE2); }
 
 //! This function returns true if the CPU has SSE3 features.
-inline bool cpu_has_sse3() { return ::SDL_HasSSE3() == SDL_TRUE; }
+inline bool cpu_has_sse3() { return detail::c_call(::SDL_HasSSE3); }
 
 //! This function returns true if the CPU has SSE4.1 features.
-inline bool cpu_has_sse41() { return ::SDL_HasSSE41() == SDL_TRUE; }
+inline bool cpu_has_sse41() { return detail::c_call(::SDL_HasSSE41); }
 
 //! This function returns true if the CPU has SSE4.2 features.
-inline bool cpu_has_sse42() { return ::SDL_HasSSE42() == SDL_TRUE; }
+inline bool cpu_has_sse42() { return detail::c_call(::SDL_HasSSE42); }
 
 //! This function returns true if the CPU has AVX features.
-inline bool cpu_has_avx() { return ::SDL_HasAVX() == SDL_TRUE; }
+inline bool cpu_has_avx() { return detail::c_call(::SDL_HasAVX); }
 
 //! This function returns true if the CPU has AVX2 features.
-inline bool cpu_has_avx2() { return ::SDL_HasAVX2() == SDL_TRUE; }
+inline bool cpu_has_avx2() { return detail::c_call(::SDL_HasAVX2); }
 
 //! This function returns the amount of RAM configured in the system, in MB.
-inline int get_system_ram() { return ::SDL_GetSystemRAM(); }
+inline int get_system_ram() { return detail::c_call(::SDL_GetSystemRAM); }
 
 } // end namespace sdl
 

--- a/include/sdl++/filesystem.hpp
+++ b/include/sdl++/filesystem.hpp
@@ -67,10 +67,9 @@ namespace sdl {
  @throws sdl::error
 */
 inline string get_base_path() {
-    char* path = nullptr;
-    SDLXX_CHECK(path = ::SDL_GetBasePath());
-
-    return detail::take_string(path);
+    auto path = detail::c_call(::SDL_GetBasePath);
+    SDLXX_CHECK(path != "");
+    return path;
 }
 
 /*!
@@ -134,11 +133,16 @@ inline string get_base_path() {
   \sa sdl::get_base_path()
  */
 inline string get_pref_path(const char* org, const char* app) {
-    char* path = nullptr;
+    auto path = detail::c_call(::SDL_GetPrefPath, org, app);
+    SDLXX_CHECK(path != "");
+    return path;
+}
 
-    SDLXX_CHECK(path = ::SDL_GetPrefPath(org, app));
-
-    return detail::take_string(path);
+//! Overload of get_pref_path() taking strings
+inline string get_pref_path(const string& org, const string& app) {
+    auto path = detail::c_call(::SDL_GetPrefPath, org, app);
+    SDLXX_CHECK(path != "");
+    return path;
 }
 
 } // end namespace sdl

--- a/include/sdl++/hints.hpp
+++ b/include/sdl++/hints.hpp
@@ -684,102 +684,102 @@ enum class hint {
     windows_no_close_on_alt_f4
 };
 
-namespace detail {
-    const char* unwrap(hint h) {
-        switch (h) {
-        case hint::framebuffer_acceleration:
-            return SDL_HINT_FRAMEBUFFER_ACCELERATION;
-        case hint::render_driver:
-            return SDL_HINT_RENDER_DRIVER;
-        case hint::render_opengl_shaders:
-            return SDL_HINT_RENDER_OPENGL_SHADERS;
-        case hint::render_direct3d_threadsafe:
-            return SDL_HINT_RENDER_DIRECT3D_THREADSAFE;
-        case hint::render_direct3d11_debug:
-            return SDL_HINT_RENDER_DIRECT3D11_DEBUG;
-        case hint::render_scale_quality:
-            return SDL_HINT_RENDER_SCALE_QUALITY;
-        case hint::render_vsync:
-            return SDL_HINT_RENDER_VSYNC;
-        case hint::video_allow_screensaver:
-            return SDL_HINT_VIDEO_ALLOW_SCREENSAVER;
-        case hint::video_x11_xvidmode:
-            return SDL_HINT_VIDEO_X11_XVIDMODE;
-        case hint::video_x11_xinerama:
-            return SDL_HINT_VIDEO_X11_XINERAMA;
-        case hint::video_x11_xrandr:
-            return SDL_HINT_VIDEO_X11_XRANDR;
-        case hint::video_x11_net_wm_ping:
-            return SDL_HINT_VIDEO_X11_NET_WM_PING;
-        case hint::window_frame_usable_while_cursor_hidden:
-            return SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN;
-        case hint::windows_enable_messageloop:
-            return SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP;
-        case hint::grab_keyboard:
-            return SDL_HINT_GRAB_KEYBOARD;
-        case hint::mouse_relative_warp_mode:
-            return SDL_HINT_MOUSE_RELATIVE_MODE_WARP;
-        case hint::video_minimize_on_focus_loss:
-            return SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS;
-        case hint::idle_timer_disabled:
-            return SDL_HINT_IDLE_TIMER_DISABLED;
-        case hint::orientations:
-            return SDL_HINT_ORIENTATIONS;
-        case hint::accelerometer_as_joystick:
-            return SDL_HINT_ACCELEROMETER_AS_JOYSTICK;
-        case hint::xinput_enabled:
-            return SDL_HINT_XINPUT_ENABLED;
-        case hint::xinput_use_old_joystick_mapping:
-            return SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING;
-        case hint::gamecontrollerconfig:
-            return SDL_HINT_GAMECONTROLLERCONFIG;
-        case hint::joystick_allow_background_events:
-            return SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS;
-        case hint::allow_topmost:
-            return SDL_HINT_ALLOW_TOPMOST;
-        case hint::timer_resolution:
-            return SDL_HINT_TIMER_RESOLUTION;
-        case hint::thread_stack_size:
-            return SDL_HINT_THREAD_STACK_SIZE;
-        case hint::video_highdpi_disabled:
-            return SDL_HINT_VIDEO_HIGHDPI_DISABLED;
-        case hint::mac_ctrl_click_emulate_right_click:
-            return SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK;
-        case hint::video_win_d3dcompiler:
-            return SDL_HINT_VIDEO_WIN_D3DCOMPILER;
-        case hint::video_window_share_pixel_format:
-            return SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT;
-        case hint::windows_no_close_on_alt_f4:
-            return SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4;
-        case hint::winrt_privacy_policy_label:
-            return SDL_HINT_WINRT_PRIVACY_POLICY_LABEL;
-        case hint::winrt_privacy_policy_url:
-            return SDL_HINT_WINRT_PRIVACY_POLICY_URL;
-        case hint::winrt_handle_back_button:
-            return SDL_HINT_WINRT_HANDLE_BACK_BUTTON;
-        case hint::video_mac_fullscreen_spaces:
-            return SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES;
-        case hint::mac_background_app:
-            return SDL_HINT_MAC_BACKGROUND_APP;
-        case hint::android_apk_expansion_main_file_version:
-            return SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION;
-        case hint::android_apk_expansion_patch_file_version:
-            return SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION;
-        case hint::ime_internal_editing:
-            return SDL_HINT_IME_INTERNAL_EDITING;
-        case hint::android_separate_mouse_and_touch:
-            return SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH;
-        case hint::emscripten_keyboard_element:
-            return SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT;
-        case hint::no_signal_handlers:
-            return SDL_HINT_NO_SIGNAL_HANDLERS;
-        default:
-            SDL_assert(false);
-        }
-        // Keep g++ happy
-        return nullptr;
+//!@cond
+inline const char* to_c_value(hint h) {
+    switch (h) {
+    case hint::framebuffer_acceleration:
+        return SDL_HINT_FRAMEBUFFER_ACCELERATION;
+    case hint::render_driver:
+        return SDL_HINT_RENDER_DRIVER;
+    case hint::render_opengl_shaders:
+        return SDL_HINT_RENDER_OPENGL_SHADERS;
+    case hint::render_direct3d_threadsafe:
+        return SDL_HINT_RENDER_DIRECT3D_THREADSAFE;
+    case hint::render_direct3d11_debug:
+        return SDL_HINT_RENDER_DIRECT3D11_DEBUG;
+    case hint::render_scale_quality:
+        return SDL_HINT_RENDER_SCALE_QUALITY;
+    case hint::render_vsync:
+        return SDL_HINT_RENDER_VSYNC;
+    case hint::video_allow_screensaver:
+        return SDL_HINT_VIDEO_ALLOW_SCREENSAVER;
+    case hint::video_x11_xvidmode:
+        return SDL_HINT_VIDEO_X11_XVIDMODE;
+    case hint::video_x11_xinerama:
+        return SDL_HINT_VIDEO_X11_XINERAMA;
+    case hint::video_x11_xrandr:
+        return SDL_HINT_VIDEO_X11_XRANDR;
+    case hint::video_x11_net_wm_ping:
+        return SDL_HINT_VIDEO_X11_NET_WM_PING;
+    case hint::window_frame_usable_while_cursor_hidden:
+        return SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN;
+    case hint::windows_enable_messageloop:
+        return SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP;
+    case hint::grab_keyboard:
+        return SDL_HINT_GRAB_KEYBOARD;
+    case hint::mouse_relative_warp_mode:
+        return SDL_HINT_MOUSE_RELATIVE_MODE_WARP;
+    case hint::video_minimize_on_focus_loss:
+        return SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS;
+    case hint::idle_timer_disabled:
+        return SDL_HINT_IDLE_TIMER_DISABLED;
+    case hint::orientations:
+        return SDL_HINT_ORIENTATIONS;
+    case hint::accelerometer_as_joystick:
+        return SDL_HINT_ACCELEROMETER_AS_JOYSTICK;
+    case hint::xinput_enabled:
+        return SDL_HINT_XINPUT_ENABLED;
+    case hint::xinput_use_old_joystick_mapping:
+        return SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING;
+    case hint::gamecontrollerconfig:
+        return SDL_HINT_GAMECONTROLLERCONFIG;
+    case hint::joystick_allow_background_events:
+        return SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS;
+    case hint::allow_topmost:
+        return SDL_HINT_ALLOW_TOPMOST;
+    case hint::timer_resolution:
+        return SDL_HINT_TIMER_RESOLUTION;
+    case hint::thread_stack_size:
+        return SDL_HINT_THREAD_STACK_SIZE;
+    case hint::video_highdpi_disabled:
+        return SDL_HINT_VIDEO_HIGHDPI_DISABLED;
+    case hint::mac_ctrl_click_emulate_right_click:
+        return SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK;
+    case hint::video_win_d3dcompiler:
+        return SDL_HINT_VIDEO_WIN_D3DCOMPILER;
+    case hint::video_window_share_pixel_format:
+        return SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT;
+    case hint::windows_no_close_on_alt_f4:
+        return SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4;
+    case hint::winrt_privacy_policy_label:
+        return SDL_HINT_WINRT_PRIVACY_POLICY_LABEL;
+    case hint::winrt_privacy_policy_url:
+        return SDL_HINT_WINRT_PRIVACY_POLICY_URL;
+    case hint::winrt_handle_back_button:
+        return SDL_HINT_WINRT_HANDLE_BACK_BUTTON;
+    case hint::video_mac_fullscreen_spaces:
+        return SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES;
+    case hint::mac_background_app:
+        return SDL_HINT_MAC_BACKGROUND_APP;
+    case hint::android_apk_expansion_main_file_version:
+        return SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION;
+    case hint::android_apk_expansion_patch_file_version:
+        return SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION;
+    case hint::ime_internal_editing:
+        return SDL_HINT_IME_INTERNAL_EDITING;
+    case hint::android_separate_mouse_and_touch:
+        return SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH;
+    case hint::emscripten_keyboard_element:
+        return SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT;
+    case hint::no_signal_handlers:
+        return SDL_HINT_NO_SIGNAL_HANDLERS;
+    default:
+        SDL_assert(false);
     }
+    // Keep g++ happy
+    return nullptr;
 }
+//!@endcond
 
 //! Priority passed to `sdl::set_hint()`
 //! Hints will replace existing hints of their priority and lower. Environment
@@ -789,6 +789,13 @@ enum class hint_priority {
     hint_normal = SDL_HINT_NORMAL,
     hint_override = SDL_HINT_OVERRIDE
 };
+
+namespace detail {
+    template <>
+    struct c_type<hint_priority> {
+        using type = SDL_HintPriority;
+    };
+}
 
 /*!
  Set a hint with optional priority
@@ -801,9 +808,7 @@ enum class hint_priority {
 */
 inline bool set_hint(hint name, const char* value,
                      hint_priority priority = hint_priority::hint_normal) {
-    return ::SDL_SetHintWithPriority(detail::unwrap(name), value,
-                                     static_cast<SDL_HintPriority>(priority)) ==
-           SDL_TRUE;
+    return detail::c_call(::SDL_SetHintWithPriority, name, value, priority);
 }
 
 /*!
@@ -812,7 +817,7 @@ inline bool set_hint(hint name, const char* value,
  @return The string value of a hint variable.
 */
 inline const char* get_hint(hint name) {
-    return ::SDL_GetHint(detail::unwrap(name));
+    return detail::c_call(::SDL_GetHint, name);
 }
 
 /*!
@@ -844,11 +849,11 @@ namespace detail {
     public:
         hint_callback(hint name, Func&& func)
             : func(std::forward<Func>(func)), name(name) {
-            ::SDL_AddHintCallback(detail::unwrap(name), run_callback, this);
+            c_call(::SDL_AddHintCallback, name, run_callback, this);
         }
 
         ~hint_callback() {
-            ::SDL_DelHintCallback(detail::unwrap(name), run_callback, this);
+            c_call(::SDL_DelHintCallback, name, run_callback, this);
         }
 
         hint_callback(hint_callback&&) = default;

--- a/include/sdl++/utils.hpp
+++ b/include/sdl++/utils.hpp
@@ -33,8 +33,11 @@ namespace sdl {
 
 namespace detail {
     inline string take_string(char* str) {
-        string s(str);
-        SDL_free(str);
+        string s;
+        if (str) {
+            s = str;
+            SDL_free(str);
+        }
         return s;
     }
 
@@ -114,14 +117,16 @@ namespace detail {
 
     inline auto to_c_value(bool arg) { return arg ? SDL_TRUE : SDL_FALSE; }
 
+    inline auto to_c_value(const string& arg) { return arg.c_str(); }
+
     template <typename T>
     decltype(auto) from_c_value(T&& arg) {
         return std::forward<T>(arg);
     }
 
-    inline auto from_c_value(SDL_bool arg) {
-        return arg == SDL_TRUE ? true : false;
-    }
+    inline auto from_c_value(SDL_bool arg) { return arg == SDL_TRUE; }
+
+    inline auto from_c_value(char* c_str) { return take_string(c_str); }
 
     struct void_return_tag {};
     struct value_return_tag {};

--- a/include/sdl++/utils.hpp
+++ b/include/sdl++/utils.hpp
@@ -112,9 +112,15 @@ namespace detail {
         return static_cast<c_type_t<std::decay_t<T>>>(arg);
     }
 
+    inline auto to_c_value(bool arg) { return arg ? SDL_TRUE : SDL_FALSE; }
+
     template <typename T>
     decltype(auto) from_c_value(T&& arg) {
         return std::forward<T>(arg);
+    }
+
+    inline auto from_c_value(SDL_bool arg) {
+        return arg == SDL_TRUE ? true : false;
     }
 
     struct void_return_tag {};

--- a/test/clipboard_test.cpp
+++ b/test/clipboard_test.cpp
@@ -25,6 +25,9 @@ TEST_CASE("SDL_clipboard.h is wrapped correctly", "clipboard") {
     SECTION("Clipboard text can be set") {
         sdl::set_clipboard_text(test_str);
         REQUIRE(SDL_strcmp(SDL_GetClipboardText(), test_str) == 0);
+
+        sdl::set_clipboard_text(sdl::string(test_str));
+        REQUIRE(SDL_strcmp(SDL_GetClipboardText(), test_str) == 0);
     }
 
     // SDL_SetClipboardText(nullptr);

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -3,6 +3,8 @@
 
 #include "catch.hpp"
 
+using namespace std::string_literals;
+
 TEST_CASE("sdl::get_base_path() is wrapped correctly", "[filesystem]") {
     char* c_path = SDL_GetBasePath();
 
@@ -15,11 +17,28 @@ TEST_CASE("sdl::get_base_path() is wrapped correctly", "[filesystem]") {
     SDL_free(c_path);
 }
 
-TEST_CASE("sdl::get_pref_path() is wrapped correctly", "[filesystem]") {
-    constexpr const char* org = "com.github.tcbrindle";
-    constexpr const char* app = "sdl++ Test";
+TEST_CASE("sdl::get_pref_path(const char*, const char*) is wrapped correctly",
+          "[filesystem]") {
+    constexpr const char org[] = "com.github.tcbrindle";
+    constexpr const char app[] = "sdl++ Test";
 
     char* c_path = SDL_GetPrefPath(org, app);
+
+    if (c_path) {
+        REQUIRE(sdl::get_pref_path(org, app) == c_path);
+    } else {
+        REQUIRE_THROWS_AS(sdl::get_pref_path(org, app), sdl::error);
+    }
+
+    SDL_free(c_path);
+}
+
+TEST_CASE("sdl::get_pref_path(string, string) is wrapped correctly",
+          "[filesystem]") {
+    const auto org = "com.github.tcbrindle"s;
+    const auto app = "sdl++ Test"s;
+
+    char* c_path = SDL_GetPrefPath(org.c_str(), app.c_str());
 
     if (c_path) {
         REQUIRE(sdl::get_pref_path(org, app) == c_path);


### PR DESCRIPTION
The first commit uses some metaprogramming magic to define a c_call() function which automatically converts the arguments from their sdl++ types to their corresponding C types.

There are customisation points available to define exactly how this conversion takes place.

The next two commits start using this machinery.
