### PR TITLE
Split utils.hpp into separate headers

### DIFF
--- a/include/sdl++/clipboard.hpp
+++ b/include/sdl++/clipboard.hpp
@@ -24,9 +24,9 @@
 
 #include "SDL_clipboard.h"
 
+#include "detail/wrapper.hpp"
 #include "macros.hpp"
 #include "stdinc.hpp"
-#include "utils.hpp"
 
 namespace sdl {
 

--- a/include/sdl++/cpuinfo.hpp
+++ b/include/sdl++/cpuinfo.hpp
@@ -26,7 +26,7 @@
 
 #include "SDL_cpuinfo.h"
 
-#include "utils.hpp"
+#include "detail/wrapper.hpp"
 
 namespace sdl {
 

--- a/include/sdl++/detail/flags.hpp
+++ b/include/sdl++/detail/flags.hpp
@@ -1,0 +1,80 @@
+/*!
+  @file flags.hpp
+  Simple DirectMedia Layer C++ Bindings
+  @copyright (C) 2016 Tristan Brindle <t.c.brindle@gmail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDLXX_DETAIL_FLAGS_HPP
+#define SDLXX_DETAIL_FLAGS_HPP
+
+#include <functional> // for bit_or
+#include <initializer_list>
+#include <numeric> // for accumulate
+#include <type_traits>
+
+namespace sdl {
+namespace detail {
+
+    template <typename EnumType>
+    struct is_flags : std::false_type {};
+
+    //! SFINAE-able type matching is_flags
+    template <typename EnumType>
+    using flags_check_t =
+        typename std::enable_if_t<is_flags<EnumType>::value, void>;
+
+    //! Helper to convert an initializer list to OR'd flags
+    template <typename EnumType, typename = flags_check_t<EnumType>>
+    EnumType ilist_to_flags(std::initializer_list<EnumType> ilist) {
+        return accumulate(cbegin(ilist), cend(ilist), static_cast<EnumType>(0),
+                          std::bit_or<>{});
+    }
+
+} // end namespace detail
+
+//! @cond
+template <typename EnumType, typename = detail::flags_check_t<EnumType>>
+constexpr EnumType operator|(EnumType lhs, EnumType rhs) {
+    using underlying = std::underlying_type_t<EnumType>;
+    return static_cast<EnumType>(static_cast<underlying>(lhs) |
+                                 static_cast<underlying>(rhs));
+}
+
+template <typename EnumType, typename = detail::flags_check_t<EnumType>>
+constexpr EnumType operator|=(EnumType& lhs, EnumType rhs) {
+    return lhs = lhs | rhs;
+}
+
+template <typename EnumType, typename = detail::flags_check_t<EnumType>>
+constexpr EnumType operator&(EnumType lhs, EnumType rhs) {
+    using underlying = std::underlying_type_t<EnumType>;
+    return static_cast<EnumType>(static_cast<underlying>(lhs) &
+                                 static_cast<underlying>(rhs));
+}
+
+template <typename EnumType, typename = detail::flags_check_t<EnumType>>
+constexpr bool flag_is_set(EnumType flags, EnumType value) {
+    using underlying = std::underlying_type_t<EnumType>;
+    return static_cast<underlying>(flags & value) != 0;
+}
+//! @endcond
+
+} // end namespace sdl
+
+#endif

--- a/include/sdl++/detail/relops.hpp
+++ b/include/sdl++/detail/relops.hpp
@@ -1,0 +1,90 @@
+/*!
+  @file relops.hpp
+  Simple DirectMedia Layer C++ Bindings
+  @copyright (C) 2016 Tristan Brindle <t.c.brindle@gmail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDLXX_DETAIL_RELOPS_HPP
+#define SDLXX_DETAIL_RELOPS_HPP
+
+#include <sdl++/utils.hpp> // for void_t
+
+#include <type_traits>
+
+namespace sdl {
+namespace detail {
+
+    template <typename T>
+    using equality_comparison_t =
+        decltype(std::declval<T>() == std::declval<T>());
+
+    template <typename T, typename = void>
+    struct is_equality_comparable : std::false_type {};
+
+    template <typename T>
+    struct is_equality_comparable<T, void_t<equality_comparison_t<T>>>
+        : std::true_type {};
+
+    template <typename T>
+    using check_equality_comparable_t =
+        std::enable_if_t<is_equality_comparable<T>::value, void>;
+
+    template <typename T>
+    using less_than_comparison_t =
+        decltype(std::declval<T>() < std::declval<T>());
+
+    template <typename T, typename = void>
+    struct is_less_than_comparable : std::false_type {};
+
+    template <typename T>
+    struct is_less_than_comparable<T, void_t<less_than_comparison_t<T>>>
+        : std::true_type {};
+
+    template <typename T>
+    using check_less_than_comparable_t =
+        std::enable_if_t<is_less_than_comparable<T>::value, void>;
+
+} // end namespace detail
+
+//! @cond
+template <typename T, typename = detail::check_equality_comparable_t<T>>
+constexpr bool operator!=(const T& lhs, const T& rhs) {
+    return !(lhs == rhs);
+}
+
+template <typename T, typename = detail::check_less_than_comparable_t<T>>
+constexpr bool operator>(const T& lhs, const T& rhs) {
+    return rhs < lhs;
+}
+
+template <typename T, typename = detail::check_less_than_comparable_t<T>>
+constexpr bool operator<=(const T& lhs, const T& rhs) {
+    return !(rhs < lhs);
+}
+
+template <typename T, typename = detail::check_less_than_comparable_t<T>>
+constexpr bool operator>=(const T& lhs, const T& rhs) {
+    return !(lhs < rhs);
+}
+
+//! @endcond
+
+} // end namespace detail
+
+#endif

--- a/include/sdl++/detail/wrapper.hpp
+++ b/include/sdl++/detail/wrapper.hpp
@@ -1,0 +1,100 @@
+/*!
+  @file wrapper.hpp
+  Simple DirectMedia Layer C++ Bindings
+  @copyright (C) 2016 Tristan Brindle <t.c.brindle@gmail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <sdl++/stdinc.hpp>
+
+#include <type_traits>
+
+#ifndef SDLXX_DETAIL_WRAPPER_HPP
+#define SDLXX_DETAIL_WRAPPER_HPP
+
+namespace sdl {
+namespace detail {
+
+    template <typename CppType>
+    struct c_type {
+        using type = CppType;
+    };
+
+    template <typename CppType>
+    using c_type_t = typename c_type<CppType>::type;
+
+    template <typename T,
+              typename = std::enable_if_t<std::is_fundamental<T>::value ||
+                                          std::is_enum<T>::value ||
+                                          std::is_pointer<T>::value>>
+    auto to_c_value(T arg) {
+        return static_cast<c_type_t<T>>(arg);
+    }
+
+    inline auto to_c_value(bool arg) { return arg ? SDL_TRUE : SDL_FALSE; }
+
+    inline auto to_c_value(const string& arg) { return arg.c_str(); }
+
+    template <typename T,
+              typename = std::enable_if_t<std::is_fundamental<T>::value ||
+                                          std::is_enum<T>::value ||
+                                          std::is_pointer<T>::value>>
+    auto from_c_value(T arg) {
+        return arg;
+    }
+
+    inline auto from_c_value(SDL_bool arg) { return arg == SDL_TRUE; }
+
+    inline auto from_c_value(char* c_str) {
+        string s;
+        if (c_str) {
+            s = c_str;
+            SDL_free(c_str);
+        }
+        return s;
+    }
+
+    struct void_return_tag {};
+    struct value_return_tag {};
+
+    template <typename CFunc, typename... CppArgs>
+    auto do_c_call(value_return_tag, CFunc c_function, CppArgs&&... args) {
+        return from_c_value(
+            c_function(to_c_value(std::forward<CppArgs>(args))...));
+    }
+
+    template <typename CFunc, typename... CppArgs>
+    void do_c_call(void_return_tag, CFunc c_function, CppArgs&&... args) {
+        c_function(to_c_value(std::forward<CppArgs>(args))...);
+    }
+
+    template <typename CFunc, typename... CppArgs>
+    auto c_call(CFunc c_function, CppArgs&&... args) {
+        constexpr bool is_void_return =
+            std::is_same<std::result_of_t<CFunc(decltype(
+                             to_c_value(std::forward<CppArgs>(args)))...)>,
+                         void>::value;
+        using return_tag = std::conditional_t<is_void_return, void_return_tag,
+                                              value_return_tag>;
+        return do_c_call(return_tag{}, c_function,
+                         std::forward<CppArgs>(args)...);
+    }
+}
+}
+
+#endif

--- a/include/sdl++/filesystem.hpp
+++ b/include/sdl++/filesystem.hpp
@@ -25,9 +25,9 @@
 
 #include "SDL_filesystem.h"
 
+#include "detail/wrapper.hpp"
 #include "macros.hpp"
 #include "stdinc.hpp"
-#include "utils.hpp"
 
 namespace sdl {
 

--- a/include/sdl++/hints.hpp
+++ b/include/sdl++/hints.hpp
@@ -26,8 +26,8 @@
 
 #include "SDL_hints.h"
 
+#include "detail/wrapper.hpp"
 #include "macros.hpp"
-#include "utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/include/sdl++/init.hpp
+++ b/include/sdl++/init.hpp
@@ -26,8 +26,9 @@
 
 #include "SDL.h"
 
+#include "detail/flags.hpp"
+#include "detail/wrapper.hpp"
 #include "macros.hpp"
-#include "utils.hpp"
 
 #include <initializer_list>
 

--- a/include/sdl++/power.hpp
+++ b/include/sdl++/power.hpp
@@ -25,8 +25,8 @@
 #ifndef SDLXX_POWER_HPP
 #define SDLXX_POWER_HPP
 
+#include "detail/relops.hpp"
 #include "stdinc.hpp"
-#include "utils.hpp"
 
 #include "SDL_power.h"
 

--- a/include/sdl++/utils.hpp
+++ b/include/sdl++/utils.hpp
@@ -23,72 +23,15 @@
 #ifndef SDLXX_UTILS_HPP
 #define SDLXX_UTILS_HPP
 
-#include "stdinc.hpp"
-
-#include <functional>
-#include <numeric>
 #include <type_traits>
 
 namespace sdl {
 
 namespace detail {
-    inline string take_string(char* str) {
-        string s;
-        if (str) {
-            s = str;
-            SDL_free(str);
-        }
-        return s;
-    }
-
-    template <typename EnumType>
-    struct is_flags : std::false_type {};
-
-    //! SFINAE-able type matching is_flags
-    template <typename EnumType>
-    using flags_check_t =
-        typename std::enable_if_t<is_flags<EnumType>::value, void>;
-
-    //! Helper to convert an initializer list to OR'd flags
-    template <typename EnumType, typename = flags_check_t<EnumType>>
-    EnumType ilist_to_flags(std::initializer_list<EnumType> ilist) {
-        return accumulate(cbegin(ilist), cend(ilist), static_cast<EnumType>(0),
-                          std::bit_or<>{});
-    }
 
     // The void_t trick
     template <typename... T>
     using void_t = void;
-
-    template <typename T>
-    using equality_comparison_t =
-        decltype(std::declval<T>() == std::declval<T>());
-
-    template <typename T, typename = void>
-    struct is_equality_comparable : std::false_type {};
-
-    template <typename T>
-    struct is_equality_comparable<T, void_t<equality_comparison_t<T>>>
-        : std::true_type {};
-
-    template <typename T>
-    using check_equality_comparable_t =
-        std::enable_if_t<is_equality_comparable<T>::value, void>;
-
-    template <typename T>
-    using less_than_comparison_t =
-        decltype(std::declval<T>() < std::declval<T>());
-
-    template <typename T, typename = void>
-    struct is_less_than_comparable : std::false_type {};
-
-    template <typename T>
-    struct is_less_than_comparable<T, void_t<less_than_comparison_t<T>>>
-        : std::true_type {};
-
-    template <typename T>
-    using check_less_than_comparable_t =
-        std::enable_if_t<is_less_than_comparable<T>::value, void>;
 
     template <typename Func, typename Ret, typename... Args>
     using check_signature_t = std::is_convertible<
@@ -102,107 +45,7 @@ namespace detail {
                            void_t<check_signature_t<Func, Ret, Args...>>>
         : std::true_type {};
 
-    template <typename CppType>
-    struct c_type {
-        using type = CppType;
-    };
-
-    template <typename CppType>
-    using c_type_t = typename c_type<CppType>::type;
-
-    template <typename T>
-    auto to_c_value(T&& arg) {
-        return static_cast<c_type_t<std::decay_t<T>>>(arg);
-    }
-
-    inline auto to_c_value(bool arg) { return arg ? SDL_TRUE : SDL_FALSE; }
-
-    inline auto to_c_value(const string& arg) { return arg.c_str(); }
-
-    template <typename T>
-    decltype(auto) from_c_value(T&& arg) {
-        return std::forward<T>(arg);
-    }
-
-    inline auto from_c_value(SDL_bool arg) { return arg == SDL_TRUE; }
-
-    inline auto from_c_value(char* c_str) { return take_string(c_str); }
-
-    struct void_return_tag {};
-    struct value_return_tag {};
-
-    template <typename CFunc, typename... CppArgs>
-    auto do_c_call(value_return_tag, CFunc c_function, CppArgs&&... args) {
-        return from_c_value(
-            c_function(to_c_value(std::forward<CppArgs>(args))...));
-    }
-
-    template <typename CFunc, typename... CppArgs>
-    void do_c_call(void_return_tag, CFunc c_function, CppArgs&&... args) {
-        c_function(to_c_value(std::forward<CppArgs>(args))...);
-    }
-
-    template <typename CFunc, typename... CppArgs>
-    auto c_call(CFunc c_function, CppArgs&&... args) {
-        constexpr bool is_void_return =
-            std::is_same<std::result_of_t<CFunc(decltype(to_c_value(args))...)>,
-                         void>::value;
-        using return_tag = std::conditional_t<is_void_return, void_return_tag,
-                                              value_return_tag>;
-        return do_c_call(return_tag{}, c_function,
-                         std::forward<CppArgs>(args)...);
-    }
-
 } // end namespace detail
-
-//! @cond
-template <typename EnumType, typename = detail::flags_check_t<EnumType>>
-constexpr EnumType operator|(EnumType lhs, EnumType rhs) {
-    using underlying = std::underlying_type_t<EnumType>;
-    return static_cast<EnumType>(static_cast<underlying>(lhs) |
-                                 static_cast<underlying>(rhs));
-}
-
-template <typename EnumType, typename = detail::flags_check_t<EnumType>>
-constexpr EnumType operator|=(EnumType& lhs, EnumType rhs) {
-    return lhs = lhs | rhs;
-}
-
-template <typename EnumType, typename = detail::flags_check_t<EnumType>>
-constexpr EnumType operator&(EnumType lhs, EnumType rhs) {
-    using underlying = std::underlying_type_t<EnumType>;
-    return static_cast<EnumType>(static_cast<underlying>(lhs) &
-                                 static_cast<underlying>(rhs));
-}
-
-template <typename EnumType, typename = detail::flags_check_t<EnumType>>
-constexpr bool flag_is_set(EnumType flags, EnumType value) {
-    using underlying = std::underlying_type_t<EnumType>;
-    return static_cast<underlying>(flags & value) != 0;
-}
-
-template <typename T, typename = detail::check_equality_comparable_t<T>>
-constexpr bool operator!=(const T& lhs, const T& rhs) {
-    return !(lhs == rhs);
-}
-
-template <typename T, typename = detail::check_less_than_comparable_t<T>>
-constexpr bool operator>(const T& lhs, const T& rhs) {
-    return rhs < lhs;
-}
-
-template <typename T, typename = detail::check_less_than_comparable_t<T>>
-constexpr bool operator<=(const T& lhs, const T& rhs) {
-    return !(rhs < lhs);
-}
-
-template <typename T, typename = detail::check_less_than_comparable_t<T>>
-constexpr bool operator>=(const T& lhs, const T& rhs) {
-    return !(lhs < rhs);
-}
-
-//! @endcond
-
 } // end namespace sdl
 
 #endif // SDLXX_UTILS_HPP

--- a/include/sdl++/version.hpp
+++ b/include/sdl++/version.hpp
@@ -27,7 +27,7 @@
 
 #include "SDL_version.h"
 
-#include "utils.hpp"
+#include "detail/relops.hpp"
 
 #include <iostream>
 


### PR DESCRIPTION
There were so many clever metafunctions in there it was hard to
see what was going on. This commit splits it up into separate
sections.

Also, restrict the templated to_c_value() and from_c_value()
to only operate on fundamental types, enums and pointers, and
to take their arguments by value. It turns out the forwarding
reference versions were too greedy and were preventing some
customised versions begin called in WIP code. This also neatly
means we can't accidentelly forget to supply the functions for
more complex SDL types.

One thing that occurs to me is that allowing passthrough for any
pointer type is probably overly broad: it may be better to
restrict it only to pointer-to-fundemental types. I'll have a
think.
